### PR TITLE
Update protocol.py for Python 3.10

### DIFF
--- a/zhong_hong_hvac/protocol.py
+++ b/zhong_hong_hvac/protocol.py
@@ -215,7 +215,7 @@ class AcStatus(ZhongHongDataStruct):
 
 
 @attr.s(slots=True)
-class AcData(collections.Iterable):
+class AcData(collections.abc.Iterable):
     header = attr.ib(init=False)  # type: Header
     payload = attr.ib(
         attr.Factory(collections.deque),


### PR DESCRIPTION
`collections.Iterable` is deprecated and removed in Python 3.10. This breaks the recent versions of HASS. Use `collections.abc.Iterable` instead.