### PR TITLE
fix issue about unable to listen to message from HVAC

### DIFF
--- a/zhong_hong_hvac/hub.py
+++ b/zhong_hong_hvac/hub.py
@@ -177,7 +177,7 @@ class ZhongHongGateway:
             self.open_socket()
 
         self._listening = True
-        thread = Thread(target=self._listen_to_msg, args=())
+        thread = Thread(target=self.thread_main, args=())
         self._threads.append(thread)
         thread.daemon = True
         thread.start()


### PR DESCRIPTION
There is an Error message for version 1.0.10~1.0.11:
ZhongHongGateway._listen_to_msg() missing 1 required positional argument :data

that is because the _listen_to_msg() needs a new arg 'data' but in start_listen():
`thread = Thread(target=self._listen_to_msg, args=())`
there is no additional arg. 

but  there is a new function 'thread_main()' seems to be unused, and this function seems to be used to handle the 'data' and _listen_to_msg(). After replace the _listen_to_msg() function with 'thread_main()':
`thread = Thread(target=self.thread_main, args=())`
 It works fine.