### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,12 @@ name = "zhong-hong-hvac"
 version = "1.0.13"
 description = "Python library for interfacing with ZhongHong HVAC controller"
 authors = ["ruohan.chen <crhan123@gmail.com>"]
-license = "Apache"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "zhong_hong_hvac"}]
 classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Poetry recommends the use of the official SPDX license expressions.
https://python-poetry.org/docs/pyproject/#license